### PR TITLE
Fix a bug in which latitude and longitude had the wrong units.

### DIFF
--- a/gnss/coord_system.py
+++ b/gnss/coord_system.py
@@ -181,10 +181,13 @@ def ecef_to_ned_matrix(ref_ecef):
     M = np.empty([3, 3])
     llh = np.array(llh_from_ecef(ref_ecef))
 
-    sin_lat = np.sin(llh[0])
-    cos_lat = np.cos(llh[0])
-    sin_lon = np.sin(llh[1])
-    cos_lon = np.cos(llh[1])
+    lat_radians = np.deg2rad(llh[0])
+    lon_radians = np.deg2rad(llh[1])
+
+    sin_lat = np.sin(lat_radians)
+    cos_lat = np.cos(lat_radians)
+    sin_lon = np.sin(lon_radians)
+    cos_lon = np.cos(lon_radians)
 
     M[0][0] = -sin_lat * cos_lon
     M[0][1] = -sin_lat * sin_lon

--- a/tests/test_coord_system.py
+++ b/tests/test_coord_system.py
@@ -80,6 +80,8 @@ def test_ecef_llh_roundtrip(x):
                           # some second order error which translate into the down
                           # component, hence the small magnitude.
                           ((0., 0., 0.01), (EARTH_A, 0, 0), (0.01, 0., 0.)),
+                          # Now try a spot check with angles
+                          ((1, 1, 1), (2, 2, 2), (1.13204490e-01, 1.11022302e-16, -1.72834740e+00))
                          ])
 def test_ned_from_ecef(vector, reference, expected):
     actual = cs.ned_from_ecef(vector, reference)


### PR DESCRIPTION
Fix a bug in which latitude and longitude had the wrong units after having changed them in #1.

@jck 