### PR TITLE
Switch to github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install Tox and any other packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run Tox
+        run: |
+          tox
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: false
-language: python
-python:
-  - "2.7"
-  - "3.6"
-install: pip install tox-travis
-script: tox


### PR DESCRIPTION
Migrate from Travis to github actions.

This was a bit awkward.  If I used the github actions matrix to specify python 2.7 and 3.6 tox would fail because it would subsequently try to test python 3.6 with a native install of python 2.7 (ie, it would try to test a newer version of python with an old one).  So at the github actions level this only lists python 3.6, but the tox tests run with 3.6 AND 2.7.