### PR TITLE
rename package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='gnss',
+    name='swiftnav-gnss',
     description='GNSS Utilities',
     author='Swift Navigation',
     author_email='dev@swiftnav.com',


### PR DESCRIPTION
Turns out we don't actually own the `gnss` package, but have been publishing it under the name `swiftnav-gnss'. 