### PR TITLE
Allow vector inputs to coord_system functions and add typing info

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install Tox and any other packages
         run: |
           python -m pip install --upgrade pip
@@ -22,4 +22,3 @@ jobs:
       - name: Run Tox
         run: |
           tox
-

--- a/gnss/__init__.py
+++ b/gnss/__init__.py
@@ -1,2 +1,2 @@
 from .coord_system import llh_from_ecef, ecef_from_llh
-from .gps_time import gps_format_to_datetime, datetime_to_gps_format
+from .gps_time import gps_format_to_datetime, datetime_to_gps_format  # type: ignore

--- a/gnss/coord_system.py
+++ b/gnss/coord_system.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2017 Swift Navigation Inc.
-# Contact: Swift Navigation <dev@swiftnav.com> 
+# Contact: Swift Navigation <dev@swiftnav.com>
 # This source is subject to the license found in the file 'LICENSE' which must
 # be be distributed together with this source. All other rights reserved.
 
@@ -229,7 +229,8 @@ def relative_position_in_ned(ecef_target, ecef_reference):
     """
     ecef_target = np.asarray(ecef_target)
     ecef_reference = np.asarray(ecef_reference)
-    return ned_from_ecef((ecef_target - ecef_reference), ecef_reference)
+    return ned_from_ecef(np.transpose(np.transpose(ecef_target) - ecef_reference),
+                         ecef_reference)
 
 
 def azimuth_elevation_from_ecef(ecef_target, ecef_reference):
@@ -263,6 +264,6 @@ def azimuth_elevation_from_ecef(ecef_target, ecef_reference):
     # atan2 returns angle in range [-pi, pi], usually azimuth is defined in the
     # range [0, 2pi]. */
     azimuth = np.mod(np.arctan2(ned[1], ned[0]), 2 * np.pi)
-    elevation = np.arcsin(-ned[2] / np.linalg.norm(ned))
+    elevation = np.arcsin(-ned[2] / np.linalg.norm(ned, axis=0))
 
     return np.rad2deg(azimuth), np.rad2deg(elevation)

--- a/gnss/gps_time.py
+++ b/gnss/gps_time.py
@@ -1,3 +1,4 @@
+# type: ignore
 # Copyright (C) 2018 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swiftnav.com>
 # This source is subject to the license found in the file 'LICENSE' which must
@@ -7,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 WEEK_SECS = 7 * 24 * 60 * 60
-GPS_WEEK_0 = np.datetime64('1980-01-06T00:00:00Z', 'ns')
+GPS_WEEK_0 = np.datetime64('1980-01-06T00:00:00', 'ns')
 
 
 def gps_format_to_datetime(wn, tow):
@@ -38,6 +39,7 @@ def gps_format_to_datetime(wn, tow):
     seconds = pd.to_timedelta(tow, 's')
     weeks = pd.to_timedelta(np.array(wn) * WEEK_SECS, 's')
     return GPS_WEEK_0 + weeks + seconds
+
 
 def datetime_to_gps_format(t):
     """
@@ -94,16 +96,16 @@ def gps_minus_utc_seconds(gpst):
       Returns the number (or an array of them) of leap second values.
     """
 
-    delta_utc = np.zeros(gpst.shape, np.int)
+    delta_utc = np.zeros(gpst.shape, int)
     delta_utc = np.array(delta_utc)
-    assert np.all(gpst >= np.datetime64('1999-01-01T00:00:13Z'))
+    assert np.all(gpst >= np.datetime64('1999-01-01T00:00:13'))
     # difference was 16 seconds on 1st July 2012, add the leap seconds since that
     delta_utc += 13
-    delta_utc[gpst >= np.datetime64('2005-01-01T00:00:13Z')] += 1
-    delta_utc[gpst >= np.datetime64('2008-01-01T00:00:14Z')] += 1
-    delta_utc[gpst >= np.datetime64('2012-07-01T00:00:15Z')] += 1
-    delta_utc[gpst >= np.datetime64('2015-07-01T00:00:16Z')] += 1
-    delta_utc[gpst >= np.datetime64('2017-01-01T00:00:17Z')] += 1
+    delta_utc[gpst >= np.datetime64('2005-01-01T00:00:13')] += 1
+    delta_utc[gpst >= np.datetime64('2008-01-01T00:00:14')] += 1
+    delta_utc[gpst >= np.datetime64('2012-07-01T00:00:15')] += 1
+    delta_utc[gpst >= np.datetime64('2015-07-01T00:00:16')] += 1
+    delta_utc[gpst >= np.datetime64('2017-01-01T00:00:17')] += 1
     return delta_utc
 
 

--- a/gnss/py.typed
+++ b/gnss/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+plugins=numpy.typing.mypy_plugin

--- a/setup.py
+++ b/setup.py
@@ -7,21 +7,25 @@ setup(
     author_email='dev@swiftnav.com',
     url='https://github.com/swift-nav/pygnss',
     packages=find_packages(),
+    package_data={
+        'gnss': ['py.typed'],
+    },
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
-    install_requires=['numpy', 'pandas>=0.23.3'],
+    install_requires=['numpy>=1.21', 'pandas>=1.0'],
     extras_require={
         'test': [
             'pytest',
             'hypothesis',
+            'mypy',
+            'pandas-stubs'
         ],
     },
     license='mit',
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tests/test_coord_system.py
+++ b/tests/test_coord_system.py
@@ -23,7 +23,8 @@ test_data = [
     ((-90, 0, 0), (0, 0, -EARTH_B)),  # South Pole
     ((90, 0, 22), (0, 0, EARTH_B + 22)),  # 22m above north pole
     ((-90, 0, 22), (0, 0, -(EARTH_B + 22))),  # 22m above south pole
-    ((0, 0, 22), (EARTH_A + 22, 0, 0)),  # 22m above the equator end prime meridian
+    # 22m above the equator end prime meridian
+    ((0, 0, 22), (EARTH_A + 22, 0, 0)),
     ((0, 180, 22), (-(EARTH_A + 22), 0, 0)),  # 22m above the equator
     ((38, 122, 0), (-2666781.2433701, 4267742.1051642, 3905443.968419)),
 ]
@@ -81,8 +82,9 @@ def test_ecef_llh_roundtrip(x):
                           # component, hence the small magnitude.
                           ((0., 0., 0.01), (EARTH_A, 0, 0), (0.01, 0., 0.)),
                           # Now try a spot check with angles
-                          ((1, 1, 1), (2, 2, 2), (1.13204490e-01, 1.11022302e-16, -1.72834740e+00))
-                         ])
+                          ((1, 1, 1), (2, 2, 2), (1.13204490e-01,
+                           1.11022302e-16, -1.72834740e+00))
+                          ])
 def test_ned_from_ecef(vector, reference, expected):
     actual = cs.ned_from_ecef(vector, reference)
     assert actual == approx(expected)
@@ -97,14 +99,25 @@ def test_ned_from_ecef(vector, reference, expected):
                           # Satellite is directly North of the reference
                           ((EARTH_A, 0, SAT_ALTITUDE), (EARTH_A, 0, 0), (0., 0.)),
                           # Satellite is east at elevation angle of 45.
-                          ((EARTH_A + SAT_ALTITUDE, 0, SAT_ALTITUDE), (EARTH_A, 0, 0), (0., 45.)),
+                          ((EARTH_A + SAT_ALTITUDE, 0, SAT_ALTITUDE),
+                           (EARTH_A, 0, 0), (0., 45.)),
                           # Satellite is north east at elevation angle of tan^-1(1, sqrt(2))
                           ((EARTH_A + SAT_ALTITUDE, SAT_ALTITUDE, SAT_ALTITUDE),
                            (EARTH_A, 0, 0),
                            (45., np.rad2deg(np.arctan2(1., np.sqrt(2))))),
-                         ])
+                          ])
 def test_azimuth_elevation_from_ecef(target, reference, expected):
     azimuth, elevation = cs.azimuth_elevation_from_ecef(target, reference)
     assert azimuth == approx(expected[0])
     assert elevation == approx(expected[1])
-    
+
+
+def test_azimuth_elevation_from_ecef_vec():
+    target = ([EARTH_A + SAT_ALTITUDE, EARTH_A, EARTH_A],
+              [0, SAT_ALTITUDE, 0],
+              [0, 0, SAT_ALTITUDE])
+    reference = (EARTH_A, 0, 0)
+    expected = ([0., 90., 0.], [90., 0., 0.])
+    azimuth, elevation = cs.azimuth_elevation_from_ecef(target, reference)
+    assert azimuth == approx(expected[0])
+    assert elevation == approx(expected[1])

--- a/tests/test_gps_time.py
+++ b/tests/test_gps_time.py
@@ -1,3 +1,4 @@
+# type: ignore
 # Copyright (C) 2016 Swift Navigation Inc.
 # Contact: engineering@swiftnav.com
 #
@@ -31,13 +32,13 @@ def assert_time_not_equal(x, y):
 
 
 @pytest.mark.parametrize("t", [
-        datetime.datetime(2000, 1, 1),
-        datetime.datetime(2016, 1, 20),
-        gps_time.GPS_WEEK_0,
-        pd.date_range(
-            start=datetime.datetime(2016, 1, 1),
-            end=datetime.datetime(2016, 1, 20)),
-        np.datetime64('2016-01-20T05:00:00.999999Z'),
+    datetime.datetime(2000, 1, 1),
+    datetime.datetime(2016, 1, 20),
+    gps_time.GPS_WEEK_0,
+    pd.date_range(
+        start=datetime.datetime(2016, 1, 1),
+        end=datetime.datetime(2016, 1, 20)),
+    np.datetime64('2016-01-20T05:00:00.999999'),
 ])
 def test_tow_datetime_roundtrip(t):
     wn_tow = gps_time.datetime_to_gps_format(t)
@@ -51,25 +52,25 @@ def test_tow_datetime_roundtrip(t):
 
 
 @pytest.mark.parametrize("utc,dt", [
-        (np.datetime64('2012-06-30T23:59:59Z'), 15),
-        (np.datetime64('2017-07-01T00:00:00Z'), 18),
+    (np.datetime64('2012-06-30T23:59:59'), 15),
+    (np.datetime64('2017-07-01T00:00:00'), 18),
 ])
 def test_gps_minus_utc_seconds(utc, dt):
     np.testing.assert_array_equal(gps_time.gps_minus_utc_seconds(utc), dt)
 
 
 @pytest.fixture(params=[
-        (np.datetime64('2015-07-01T00:00:15Z'),
-         np.datetime64('2015-06-30T23:59:59Z')),
-        (np.datetime64('2015-07-01T00:00:15.9999Z'),
-         np.datetime64('2015-06-30T23:59:59.9999Z')),
-        (np.datetime64('2015-07-01T00:00:17Z'),
-         np.datetime64('2015-07-01T00:00:00Z')),
-        (np.datetime64('2017-01-01T00:00:16Z'),
-         np.datetime64('2016-12-31T23:59:59Z')),
-        (np.datetime64('2017-01-01T00:00:18Z'),
-         np.datetime64('2017-01-01T00:00:00Z')),
-    ])
+    (np.datetime64('2015-07-01T00:00:15'),
+     np.datetime64('2015-06-30T23:59:59')),
+    (np.datetime64('2015-07-01T00:00:15.9999'),
+     np.datetime64('2015-06-30T23:59:59.9999')),
+    (np.datetime64('2015-07-01T00:00:17'),
+     np.datetime64('2015-07-01T00:00:00')),
+    (np.datetime64('2017-01-01T00:00:16'),
+     np.datetime64('2016-12-31T23:59:59')),
+    (np.datetime64('2017-01-01T00:00:18'),
+     np.datetime64('2017-01-01T00:00:00')),
+])
 def gpst_to_utc_testcase(request):
     # GPS time and corresponding UTC time
     # Unfortunately Python datetime64 cannot handle leap second

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
-envlist = py27, py36
+envlist = py37
 
 [testenv]
 extras=test
-commands=pytest
+commands=
+    pytest
+    mypy gnss/ tests/


### PR DESCRIPTION
I found some issues when the inputs to the coord_system package functions were vectors of coordinates, this PR fixes that.

I also added type hints to all the functions.

I also updated the tests to Python 3.8 as that is what I get on Ubuntu 20.04

@joelynch can you double check the type hints? I think I got this correct, and mypy seems to be OK with it.