### PR TITLE
Use np.float64 for numpy 2.0 compatibility

### DIFF
--- a/gnss/coord_system.py
+++ b/gnss/coord_system.py
@@ -63,7 +63,7 @@ def llh_from_ecef(ecef: ArrayLike) -> Coordinate:
     p = np.linalg.norm((x, y))
 
     # Compute longitude first, this can be done exactly.
-    if p == 0.0:
+    if np.allclose(p, 0.0):
         lon = np.zeros(np.array(x).shape, float)
     else:
         lon = np.arctan2(y, x)

--- a/gnss/coord_system.py
+++ b/gnss/coord_system.py
@@ -5,12 +5,13 @@
 
 
 from typing import List, Tuple, Union
+
 import numpy as np
 import numpy.typing as npt
 
 ArrayLike = Union[List, Tuple, np.ndarray]
 Coordinate = Tuple[
-    npt.NDArray[np.float_], npt.NDArray[np.float_], npt.NDArray[np.float_]
+    npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]
 ]
 
 WGS84_A: float = 6378137.0
@@ -178,7 +179,7 @@ def ecef_from_llh(llh: ArrayLike) -> Coordinate:
     return x, y, z
 
 
-def ecef_to_ned_matrix(ref_ecef: ArrayLike) -> npt.NDArray[np.float_]:
+def ecef_to_ned_matrix(ref_ecef: ArrayLike) -> npt.NDArray[np.float64]:
     """Populates a provided 3x3 matrix with the appropriate rotation
     matrix to transform from ECEF to NED coordinates, given the
     provided ECEF reference vector.
@@ -209,14 +210,14 @@ def ecef_to_ned_matrix(ref_ecef: ArrayLike) -> npt.NDArray[np.float_]:
 
 def ned_from_ecef(
     ecef_vector: ArrayLike, reference_location: ArrayLike
-) -> npt.NDArray[np.float_]:
+) -> npt.NDArray[np.float64]:
     """Convert ECEF coordinates into NED frame of given reference."""
     return np.dot(ecef_to_ned_matrix(reference_location), ecef_vector)
 
 
 def relative_position_in_ned(
     ecef_target: ArrayLike, ecef_reference: ArrayLike
-) -> npt.NDArray[np.float_]:
+) -> npt.NDArray[np.float64]:
     """Returns the vector between two ECEF points in the NED frame of the
     reference.
 
@@ -244,7 +245,7 @@ def relative_position_in_ned(
 
 def azimuth_elevation_from_ecef(
     ecef_target: ArrayLike, ecef_reference: ArrayLike
-) -> Tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
+) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """Returns the azimuth and elevation of a vector pointing from `ref_position`
     to `position` where both are given in ECEF
 


### PR DESCRIPTION
`np.float_` was removed from `numpy >= 2.0`.

When using it, we get:

```
  File "/Users/mallen/workspace/condor/.venv/lib/python3.10/site-packages/gnss/coord_system.py", line 13, in <module>
    npt.NDArray[np.float_], npt.NDArray[np.float_], npt.NDArray[np.float_]
  File "/Users/mallen/workspace/condor/.venv/lib/python3.10/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.. Did you mean: 'float16'?
```

This PR replaces it with the recommended `np.float64`